### PR TITLE
Use julia 0.6 and NLPModels 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ os:
   - osx
 
 julia:
-  - 0.5
+  - 0.6
   - nightly
+
+matrix:
+  allow_failures:
+    - nightly
 
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.5
+julia 0.6
+NLPModels 0.3.0

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+ForwardDiff 0.2.5


### PR DESCRIPTION
I ended up pushing the change of NLSModels to NLPModels directly to master.

Closes #1 