### PR TITLE
Update constraints treated as ScalarQuadraticFunctions by JuMP

### DIFF
--- a/src/LVcon512.jl
+++ b/src/LVcon512.jl
@@ -37,11 +37,11 @@ function LVcon512(n :: Int=21)
   for k = 1:3N
     ℓ = 4 * div(k - 1, 3)
     if k % 3 == 1
-      @constraint(model, x[ℓ + 1] + x[ℓ + 2]^2 + x[ℓ + 3]^2 == 3)
+      @NLconstraint(model, x[ℓ + 1] + x[ℓ + 2]^2 + x[ℓ + 3]^2 == 3)
     elseif k % 3 == 2
-      @constraint(model, x[ℓ + 2] + x[ℓ + 3]^2 + x[ℓ + 4] == 1)
+      @NLconstraint(model, x[ℓ + 2] + x[ℓ + 3]^2 + x[ℓ + 4] == 1)
     else
-      @constraint(model, x[ℓ + 1] * x[ℓ + 5] == 1)
+      @NLconstraint(model, x[ℓ + 1] * x[ℓ + 5] == 1)
     end
   end
 

--- a/src/LVcon513.jl
+++ b/src/LVcon513.jl
@@ -36,10 +36,9 @@ function LVcon513(n :: Int=20)
   for k = 1:2N
     ℓ = 3 * div(k - 1, 2)
     if k % 2 == 1
-      @constraint(model, x[ℓ + 1] + x[ℓ + 2]^2 + x[ℓ + 3] + x[ℓ + 4] +
-                  x[ℓ + 5] == 5)
+      @NLconstraint(model, x[ℓ + 1] + x[ℓ + 2]^2 + x[ℓ + 3] + x[ℓ + 4] + x[ℓ + 5] == 5)
     else
-      @constraint(model, x[ℓ + 3]^2 - 2 * (x[ℓ + 4] + x[ℓ + 5]) == 3)
+      @NLconstraint(model, x[ℓ + 3]^2 - 2 * (x[ℓ + 4] + x[ℓ + 5]) == 3)
     end
   end
 

--- a/src/LVcon514.jl
+++ b/src/LVcon514.jl
@@ -37,9 +37,9 @@ function LVcon514(n :: Int=20)
   for k = 1:2N
     ℓ = 3 * div(k - 1, 2)
     if k % 2 == 1
-      @constraint(model, x[ℓ + 1]^2 + x[ℓ + 2] + x[ℓ + 3] + 4 * x[ℓ + 4] == 7)
+      @NLconstraint(model, x[ℓ + 1]^2 + x[ℓ + 2] + x[ℓ + 3] + 4 * x[ℓ + 4] == 7)
     else
-      @constraint(model, x[ℓ + 3]^2 - 5 * x[ℓ + 5] == 6)
+      @NLconstraint(model, x[ℓ + 3]^2 - 5 * x[ℓ + 5] == 6)
     end
   end
 

--- a/src/LVcon515.jl
+++ b/src/LVcon515.jl
@@ -37,11 +37,11 @@ function LVcon515(n :: Int=21)
   for k = 1:3N
     ℓ = 4 * div(k - 1, 3)
     if k % 3 == 1
-      @constraint(model, x[ℓ + 1]^2 + 2 * x[ℓ + 2] + 3 * x[ℓ + 3] == 6)
+      @NLconstraint(model, x[ℓ + 1]^2 + 2 * x[ℓ + 2] + 3 * x[ℓ + 3] == 6)
     elseif k % 3 == 2
-      @constraint(model, x[ℓ + 2]^2 + 2 * x[ℓ + 3] + 3 * x[ℓ + 4] == 6)
+      @NLconstraint(model, x[ℓ + 2]^2 + 2 * x[ℓ + 3] + 3 * x[ℓ + 4] == 6)
     else
-      @constraint(model, x[ℓ + 3]^2 + 2 * x[ℓ + 4] + 3 * x[ℓ + 5] == 6)
+      @NLconstraint(model, x[ℓ + 3]^2 + 2 * x[ℓ + 4] + 3 * x[ℓ + 5] == 6)
     end
   end
 

--- a/src/LVcon516.jl
+++ b/src/LVcon516.jl
@@ -37,11 +37,11 @@ function LVcon516(n :: Int=21)
   for k = 1:3N
     ℓ = 4 * div(k - 1, 3)
     if k % 3 == 1
-      @constraint(model, x[ℓ + 1]^2 + 3 * x[ℓ + 2] == 4)
+      @NLconstraint(model, x[ℓ + 1]^2 + 3 * x[ℓ + 2] == 4)
     elseif k % 3 == 2
-      @constraint(model, x[ℓ + 3]^2 + x[ℓ + 4] - 2 * x[ℓ + 5] == 0)
+      @NLconstraint(model, x[ℓ + 3]^2 + x[ℓ + 4] - 2 * x[ℓ + 5] == 0)
     else
-      @constraint(model, x[ℓ + 2]^2 - x[ℓ + 5] == 0)
+      @NLconstraint(model, x[ℓ + 2]^2 - x[ℓ + 5] == 0)
     end
   end
 

--- a/src/LVcon517.jl
+++ b/src/LVcon517.jl
@@ -36,11 +36,11 @@ function LVcon517(n :: Int=21)
   for k = 1:3N
     ℓ = 4 * div(k - 1, 3)
     if k % 3 == 1
-      @constraint(model, x[ℓ + 1]^2 + 3 * x[ℓ + 2] == 0)
+      @NLconstraint(model, x[ℓ + 1]^2 + 3 * x[ℓ + 2] == 0)
     elseif k % 3 == 2
-      @constraint(model, x[ℓ + 3]^2 + x[ℓ + 4] - 2 * x[ℓ + 5] == 0)
+      @NLconstraint(model, x[ℓ + 3]^2 + x[ℓ + 4] - 2 * x[ℓ + 5] == 0)
     else
-      @constraint(model, x[ℓ + 2]^2 - x[ℓ + 5] == 0)
+      @NLconstraint(model, x[ℓ + 2]^2 - x[ℓ + 5] == 0)
     end
   end
 

--- a/src/LVcon518.jl
+++ b/src/LVcon518.jl
@@ -36,11 +36,11 @@ function LVcon518(n :: Int=21)
   for k = 1:3N
     ℓ = 4 * div(k - 1, 3)
     if k % 3 == 1
-      @constraint(model, x[ℓ + 1]^2 + 3 * x[ℓ + 2] == 0)
+      @NLconstraint(model, x[ℓ + 1]^2 + 3 * x[ℓ + 2] == 0)
     elseif k % 3 == 2
-      @constraint(model, x[ℓ + 3]^2 + x[ℓ + 4] - 2 * x[ℓ + 5] == 0)
+      @NLconstraint(model, x[ℓ + 3]^2 + x[ℓ + 4] - 2 * x[ℓ + 5] == 0)
     else
-      @constraint(model, x[ℓ + 2]^2 - x[ℓ + 5] == 0)
+      @NLconstraint(model, x[ℓ + 2]^2 - x[ℓ + 5] == 0)
     end
   end
 

--- a/src/hs57.jl
+++ b/src/hs57.jl
@@ -29,7 +29,7 @@ function hs57(args...)
   set_start_value.(x, [0.42; 5.0])
   @NLexpression(model, F[i=1:44], b[i] - x[1] - (0.49 - x[1]) *
                 exp(-x[2] * (a[i] - 8)))
-  @constraint(model, 0.49 * x[2] - x[1] * x[2] ≥ 0.09)
+  @NLconstraint(model, 0.49 * x[2] - x[1] * x[2] ≥ 0.09)
 
   return MathOptNLSModel(model, F, name="hs57")
 end

--- a/src/tp326.jl
+++ b/src/tp326.jl
@@ -21,7 +21,7 @@ function tp326(args...)
   @NLexpression(nls, F1, x[1] - 8)
   @NLexpression(nls, F2, x[2] - 5)
 
-  @constraint(nls, 11 - x[1]^2 + 6 * x[1] - 4 * x[2] ≥ 0)
+  @NLconstraint(nls, 11 - x[1]^2 + 6 * x[1] - 4 * x[2] ≥ 0)
   @NLconstraint(nls, x[1] * x[2] - 3 * x[2] - exp(x[1] - 3) + 1 ≥ 0)
 
   return MathOptNLSModel(nls, [F1; F2], name="tp326")


### PR DESCRIPTION
With a `MathOptNLSModel`, only linear constraints (@ constraint) and non-linear constraints (@ NLconstraint) can be parsed. I modified quadratic constraints (@ constraint) such that we can read them.

With `NLPModelsJuMP` 0.6.2 and this pull request, everything works as before with `MathProgBase`.